### PR TITLE
refactor: adds support for AGP 8.0+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,10 @@ android {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+    
+    namespace 'io.flutter.plugins.localauth'
+
+    lint {
         disable 'InvalidPackage'
     }
 }

--- a/test/local_auth_test.dart
+++ b/test/local_auth_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:local_auth/auth_strings.dart';


### PR DESCRIPTION
- Added namespace inside android/build.gradle to support AGP 8.0+
- rename `lintOptions` to `lint` to support new syntax